### PR TITLE
Correct handling of Linux SLL header and VLAN headers.

### DIFF
--- a/src/Storage.hh
+++ b/src/Storage.hh
@@ -102,6 +102,7 @@ public:
 	friend void *capture_thread(void *arg);
 private:
 	pcap_t *ph;
+	int linktype;
 	int snaplen;
 	pthread_t capture_thread_tid;
 	pthread_attr_t capture_thread_attr;

--- a/src/packet_headers.h
+++ b/src/packet_headers.h
@@ -5,6 +5,7 @@
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>
+#include <pcap/sll.h>
 #ifdef linux
 #define __FAVOR_BSD
 #endif
@@ -41,6 +42,17 @@ struct icmphdr {
 /* #define ETHER_HDR_LEN		sizeof(struct ether_header) */
 
 #define ETHERNET(packet)    ((struct ether_header *)packet)
+// XXX: This is exceptionally ugly hack:
+//   Ethernet is by far not the only one link layer protocol and
+//   therefore it MUST NOT be assumed! In case e.g. VLAN header
+//   is present, packet pointer has to be set 4 bytes (length of
+//   VLAN header) into the Ethernet header in order to accomodate
+//   for this hack. Even more problems will occur in case we are
+//   not on Ethernet at all (what if there is some other link layer
+//   header which is actually shorter than Ethernet one? It will require
+//   'packet' to point to memory which actually is not ours (delta
+//   bytes before it)!!!
+//   All of these hacks MUST to be found and corrected.
 #define IP(packet)          ((struct ip *)(packet+ETHER_HDR_LEN))
 
 
@@ -48,5 +60,10 @@ struct icmphdr {
 
 #define TCP(packet)         ((struct tcphdr *)((char*)IP(packet)+IP_HDR_LEN(packet)))
 #define UDP(packet)         ((struct udphdr *)((char*)IP(packet)+IP_HDR_LEN(packet)))
+
+/* this is in pcap/sll.h */
+
+#define LINUX_SLL_HDR_LEN   sizeof(struct sll_header)
+#define LINUX_SLL(packet)   ((struct sll_header *)packet)
 
 #endif


### PR DESCRIPTION
In case libpcap is instructed to capture "any" interface, Linux "cooked" capture encapsulation a.k.a. Linux SLL link layer header will be used (instead of e.g. Ethernet header). Timemachine always blindly assumed Ethernet header and tried to parse it even if there was something completely different (note that Ethernet and Linux SLL are by far not the only two link layer headers that may be encountered).

There was also a problem with VLAN header, where Timemachine always blindly assumed that there is single VLAN header encapsulating IPv4 header. First, several VLAN headers MAY be encapsulated in one another. Second, there is no guarantee that IPv4 header will be used.

As all these problems were present in single piece of code, all of them have been solved by this patch.
