### PR TITLE
When deleting connections hashtable, delete stored connections as well.

### DIFF
--- a/src/Connections.cc
+++ b/src/Connections.cc
@@ -19,6 +19,14 @@ Connections::Connections(uint32_t hash_size):
 }
 
 Connections::~Connections() {
+	for(size_t i = 0; i < size; ++i) {
+		Connection *c = htable[i];
+		while(c) {
+			Connection *c_del = c;
+			c = c->col_next;
+			delete c_del;
+		}
+	}
 	delete[] htable;
 	pthread_mutex_destroy(&lock_mutex);
 }


### PR DESCRIPTION
Connections stored in hash table did not get deleted when hash table has been deleted itself.
